### PR TITLE
Fix in debug variant(default)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,9 @@ android {
             versionNameSuffix '-develop'
             manifestPlaceholders["appName"] = "Pacto[D]"
         }
+        debug {
+            initWith(buildTypes.develop)
+        }
     }
 }
 


### PR DESCRIPTION
This PR features the debug variant fix. Where the error was detected regarding the fact that in default mode variables were not being assigned in the toponym.

### Changes

- Extends the development variant to implement the default in inheritance.